### PR TITLE
Potential fix for code scanning alert no. 18: Missing rate limiting

### DIFF
--- a/unicorn-x/server-working.cjs
+++ b/unicorn-x/server-working.cjs
@@ -1,6 +1,7 @@
 const express = require('express');
 const path = require('path');
 const { Client } = require('@notionhq/client');
+const rateLimit = require('express-rate-limit');
 
 const app = express();
 const PORT = 3000;
@@ -552,7 +553,13 @@ app.post('/api/command', async (req, res) => {
 });
 
 // Main dashboard page
-app.get('/', (req, res) => {
+const dashboardLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 30, // limit each IP to 30 requests per windowMs
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+app.get('/', dashboardLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/notion-mcp-server/security/code-scanning/18](https://github.com/billlzzz10/notion-mcp-server/security/code-scanning/18)

To fix the problem, we should add a rate-limiting middleware to the Express app to limit the number of requests that can be made to endpoints that perform expensive operations, such as serving files from disk. The best way to do this is to use the well-known `express-rate-limit` package. We should import this package, configure a rate limiter (e.g., allowing a reasonable number of requests per minute), and apply it to the `'/'` route handler. This can be done by adding the rate limiter as middleware specifically to the `'/'` route, so that other routes are unaffected unless they also need rate limiting. The required changes are: (1) import `express-rate-limit`, (2) define a rate limiter, and (3) apply it to the `'/'` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
