### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/scripts/push-to-notion.js
+++ b/scripts/push-to-notion.js
@@ -90,9 +90,15 @@ function parseMarkdownFile(content, filePath) {
   }
 
   // Clean content (remove title and metadata sections)
-  const cleanContent = content
-    .replace(/^#\s+.+$/m, '') // Remove title
-    .replace(/<!--[\s\S]*?-->/g, '') // Remove comments
+  let cleanContent = content
+    .replace(/^#\s+.+$/m, ''); // Remove title
+  // Remove all HTML comments, even if nested or overlapping
+  let prevContent;
+  do {
+    prevContent = cleanContent;
+    cleanContent = cleanContent.replace(/<!--[\s\S]*?-->/g, '');
+  } while (cleanContent !== prevContent);
+  cleanContent = cleanContent
     .replace(/\*\*[^*]+\*\*:\s*.+$/gm, '') // Remove metadata lines
     .replace(/^---$/gm, '') // Remove separators
     .replace(/^\*Synced from.*$/gm, '') // Remove sync notices


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/notion-mcp-server/security/code-scanning/6](https://github.com/billlzzz10/notion-mcp-server/security/code-scanning/6)

To fix the incomplete multi-character sanitization, we should ensure that all instances of HTML comments are fully removed, even if new comment tags appear after a replacement. The best way to do this without changing existing functionality is to repeatedly apply the replacement until no more matches are found. This can be done by wrapping the replacement in a loop that continues until the content no longer changes. The change should be made in the `parseMarkdownFile` function, specifically in the block that removes comments from the content (line 95). No new dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
