### PR TITLE
Potential fix for code scanning alert no. 14: Use of externally-controlled format string

### DIFF
--- a/unicorn-x/src/services/AIGatewayBridge.ts
+++ b/unicorn-x/src/services/AIGatewayBridge.ts
@@ -534,7 +534,7 @@ export class AIGatewayBridge {
         try {
           listener(data);
         } catch (error) {
-          console.error(`Error in event listener for ${eventName}:`, error);
+          console.error('Error in event listener for %s:', eventName, error);
         }
       });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz10/notion-mcp-server/security/code-scanning/14](https://github.com/billlzzz10/notion-mcp-server/security/code-scanning/14)

To fix the issue, we should sanitize the `eventName` before including it in the log message. A safe approach is to use a `%s` format specifier and pass `eventName` as an argument to `console.error`. This ensures that the value is treated as a string and prevents any unintended formatting or injection issues.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
